### PR TITLE
Initialize mongo database with latest mongodump from "genome-nexus-mongo-dump" s3 bucket.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM mongo:3.6.2
 COPY data/ /data/
 RUN rm -rf /data/*/input /data/*/tmp
 
+RUN apt-get update && apt-get install -y wget
+RUN mkdir /mongodump
+RUN chmod ug+rw -R /mongodump
+
 # Import data into mongodb
 COPY scripts/import_mongo.sh /docker-entrypoint-initdb.d/
 CMD ["mongod"]


### PR DESCRIPTION
- Multiple versions up mongdumps are stored in the s3 bucket. The filename for the latest mongodump is stored in flat text file in s3 bucket called "latest_mongo_dump.txt".
- Download and extract latest mongodump based on the filename stored in "latest_mongo_dump.txt". Run mongorestore on extracted contents.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>