### PR TITLE
Import data in builder container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # This base image starts up mongo
 # This version needs to correspond with the helm chart version
-FROM bitnami/mongodb:4.0.12
+ARG MONGODBVERSION=4.0.12
+FROM bitnami/mongodb:${MONGODBVERSION} as build
 
 # Use .dockerignore file to ignore unwanted files
 # These files are used by import_mongo.sh to initialize mongo
@@ -13,4 +14,7 @@ USER 1001
 
 # Import data into mongodb
 COPY scripts/import_mongo.sh /docker-entrypoint-initdb.d/
+RUN /setup.sh
 
+FROM bitnami/mongodb:${MONGODBVERSION}
+COPY --from=build /bitnami/mongodb /bitnami/mongodb

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ COPY scripts/import_mongo.sh /docker-entrypoint-initdb.d/
 RUN /setup.sh
 
 FROM bitnami/mongodb:${MONGODBVERSION}
-COPY --from=build /bitnami/mongodb /bitnami/mongodb
+COPY --from=build /bitnami/mongodb /bitnami/seed
+COPY /scripts/startup.sh /startup.sh
+
+CMD [ "/startup.sh" ]

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DIR=/bitnami/mongodb
+
+if [ -d "$DIR/data/db" ]; then
+    echo "Data directory exists. Skipping."
+else
+    echo "Data directory not existing. Initializing seed in $DIR"
+    rm -rf $DIR/db
+    cp -r /bitnami/seed/* $DIR
+fi
+
+/setup.sh
+/run.sh


### PR DESCRIPTION
Right now with every `docker-compose up` all the data will be imported when the container is started. This causes heavy load on each startup even when the data files are located in a separate volume.

My proposal would be to import the data prior in a builder container and copy them to a fresh production container. This also reduces size as the image does not contain all the raw data anymore.
Also I made sure that volumes binding to `/bitnami/mongodb/` will not cause anything to fail. In that case data will be copied to the volume before the container starts.

This can also be a foundation to preload additional data sources like MutationAssessor.