### PR TITLE
Fix Missing value IMAGE_TAG grcm image error

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Extract branch or tag name
         # The GITHUB_REF variable is like "refs/head/branch_name"
         # The format of image tag is e.g. v0.12_grch38_ensembl95
-        run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/}_${Version}"
-        id: extract_tag
+        run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/}_${Version})"
+        id: extract_tags
       - name: 'Docker build with cache'
         uses: whoan/docker-build-with-cache-action@v5
         with:


### PR DESCRIPTION
Fix grcm image error: 
Error message:
```
| [Action Step] Checking required input...
| INFO: Missing value IMAGE_TAG
[Docker Image CI/build_and_publish_grcm38]   ❌  Failure - Main Docker build with cache
[Docker Image CI/build_and_publish_grcm38] exit with `FAILURE`: 1
[Docker Image CI/build_and_publish_grcm38] 🏁  Job failed
Error: Job 'build_and_publish_grcm38' failed
```