### PR TITLE
Use circle ci to publish docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,60 +1,125 @@
 version: 2.1
-# jobs:
-#   build:
-#     working_directory: ~/repo
-#     docker:
-#       - image: circleci/python:3.6.1
-#     steps:
-#       - checkout
-#       - restore_cache:
-#           key: deps1-{{ .Branch }}-{{ checksum "scripts/requirements.txt" }}
-#       - run:
-#           command: |
-#             python3 -m venv venv
-#             . venv/bin/activate
-#             pip install -r scripts/requirements.txt
-#       - save_cache:
-#           key: deps1-{{ .Branch }}-{{ checksum "scripts/requirements.txt" }}
-#           paths:
-#             - "venv"
-#       - run:
-#           command: |
-#             . venv/bin/activate
-#             cd scripts
-#             nosetests
-
 jobs:
-  build_and_publish_grch37_mutationassessor:
+  build_and_publish_grch37:
     docker:
       - image: cimg/go:1.17
-    # large is the best image for free tier users
     resource_class: large 
     steps:
       - checkout
-      # ... steps for building/testing app ...
+      # steps for building/testing app
       - run:
           name: Get Git tag
           command: |
             git fetch --tags
             echo 'export GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//g')' >> "$BASH_ENV"
             source "$BASH_ENV"
-            echo $GIT_TAG
       - setup_remote_docker:
           docker_layer_caching: true
-
       # build and push Docker image
-      # For test only, change to genomenexus docker account!!!
+      - run: |
+          TAG=${GIT_TAG}
+          IMAGE=genomenexus/gn-mongo
+          docker build -t $IMAGE:$TAG .
+          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+          docker push $IMAGE:$TAG
+  
+  build_and_publish_grch37_mutationassessor:
+    docker:
+      - image: cimg/go:1.17
+    resource_class: large 
+    steps:
+      - checkout
+      # steps for building/testing app
+      - run:
+          name: Get Git tag
+          command: |
+            git fetch --tags
+            echo 'export GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//g')' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - setup_remote_docker:
+          docker_layer_caching: true
+      # build and push Docker image
       - run: |
           TAG=${GIT_TAG}_mutationassessor
-          IMAGE=leexdocker/gn-mongodb
+          IMAGE=genomenexus/gn-mongo
           docker build -t $IMAGE:$TAG --build-arg MUTATIONASSESSOR=true .
+          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+          docker push $IMAGE:$TAG
+
+  build_and_publish_grch38:
+    docker:
+      - image: cimg/go:1.17
+    resource_class: large 
+    steps:
+      - checkout
+      # steps for building/testing app
+      - run:
+          name: Get Git tag
+          command: |
+            git fetch --tags
+            echo 'export GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//g')' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - setup_remote_docker:
+          docker_layer_caching: true
+      # build and push Docker image
+      - run: |
+          TAG=${GIT_TAG}_grch38_ensembl95
+          IMAGE=genomenexus/gn-mongo
+          docker build -t $IMAGE:$TAG --build-arg ARG_REF_ENSEMBL_VERSION=grch38_ensembl95 .
+          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+          docker push $IMAGE:$TAG
+  
+  build_and_publish_grcm38:
+    docker:
+      - image: cimg/go:1.17
+    resource_class: large 
+    steps:
+      - checkout
+      # steps for building/testing app
+      - run:
+          name: Get Git tag
+          command: |
+            git fetch --tags
+            echo 'export GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//g')' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - setup_remote_docker:
+          docker_layer_caching: true
+      # build and push Docker image
+      - run: |
+          TAG=${GIT_TAG}_grcm38_ensembl95
+          IMAGE=genomenexus/gn-mongo
+          docker build -t $IMAGE:$TAG --build-arg SPECIES=mus_musculus --build-arg ARG_REF_ENSEMBL_VERSION=grcm38_ensembl95 .
           echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
           docker push $IMAGE:$TAG
 
 workflows:
   build:
     jobs:
+      - build_and_publish_grch37:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /.*/
+
       - build_and_publish_grch37_mutationassessor:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /.*/
+
+      - build_and_publish_grch38:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /.*/
+              
+      - build_and_publish_grcm38:
           filters:
             branches:
               ignore:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,8 +4,8 @@ on:
     branches: 
       - master
       - demo-*
-    tags: '*'
-
+# Only use GitHub Actions for testing, because the Docker image with Mutation Assessor data is too big to be built and pushed.
+# CircleCI builds and pushes the images to Docker Hub for every new release.
 jobs:
   build_and_publish_grch37:
     if: github.repository == 'genome-nexus/genome-nexus-importer'
@@ -23,34 +23,9 @@ jobs:
       - name: 'Docker build with cache'
         uses: whoan/docker-build-with-cache-action@v5
         with:
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
           image_name: genomenexus/gn-mongo
           image_tag: ${{ steps.extract_tags.outputs.image_tag_names }}
-          pull_image_and_stages: false
-
-  build_and_publish_grch37_mutationassessor:
-    if: github.repository == 'genome-nexus/genome-nexus-importer'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout git repo'
-        uses: actions/checkout@v1
-      - name: Extract branch or tag name
-        # The GITHUB_REF variable is like "refs/head/branch_name" or
-        # "refs/tag/tag_name". If the tag is prefixed with v, this is a new
-        # version and we want to push it with the tag "latest" as well. One can give 
-        # the same image multiple tags by using ","
-        run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/}_mutationassessor | sed 's/^v/latest,/g')"
-        id: extract_tags
-      - name: 'Docker build with cache'
-        uses: whoan/docker-build-with-cache-action@v5
-        with:
-          build_extra_args: '--build-arg MUTATIONASSESSOR=true'
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
-          image_name: genomenexus/gn-mongo
-          image_tag: ${{ steps.extract_tags.outputs.image_tag_names }}
-          pull_image_and_stages: false
+          push_image_and_stages: false
   
   build_and_publish_grch38:
     if: github.repository == 'genome-nexus/genome-nexus-importer'
@@ -69,11 +44,9 @@ jobs:
         uses: whoan/docker-build-with-cache-action@v5
         with:
           build_extra_args: '{"--build-arg": "ARG_REF_ENSEMBL_VERSION=grch38_ensembl95"}'
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
           image_name: genomenexus/gn-mongo
           image_tag: ${{ steps.extract_tag.outputs.image_tag_name }}
-          pull_image_and_stages: false
+          push_image_and_stages: false
 
   build_and_publish_grcm38:
     if: github.repository == 'genome-nexus/genome-nexus-importer'
@@ -92,9 +65,7 @@ jobs:
         uses: whoan/docker-build-with-cache-action@v5
         with:
           build_extra_args: '--build-arg SPECIES=mus_musculus --build-arg REF_ENSEMBL_VERSION=grcm38_ensembl95'
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
           image_name: genomenexus/gn-mongo
           image_tag: ${{ steps.extract_tags.outputs.image_tag_names }}
-          pull_image_and_stages: false
+          push_image_and_stages: false
           


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/727
Github action cannot build docker images any more because the size of image becomes too big. Use circle ci to build and publish docker images.